### PR TITLE
updated the pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To run the Solar Pi you need
 
 - Clone the repostory
 
-        $ git clone git@github.com:Tafkas/solarpi.git solarpi
+        $ git clone https://github.com/Tafkas/solarpi.git
 
 - create a virtual enviroment and activate it
 


### PR DESCRIPTION
the old way of cloning doesn't work anymore, it complains about permissions problems.  updated to reflect new way, found a fix and worked: https://stackoverflow.com/questions/23766153/git-clone-ssh-permission-denied